### PR TITLE
[ajout] Ecran de création d'un utilisateur

### DIFF
--- a/srcs/ecruti.cbl
+++ b/srcs/ecruti.cbl
@@ -17,7 +17,7 @@
       * TRT=TIRET; BAR=BARRE; CRG=CROCHET GAUCHE; CRD=CROCHET DROIT;   *
       * CHX=CHOIX; CFM=CONFIRMATION; AFF=AFFICHAGE; DEB=DEBUT;         *
       * MSG=MESSAGE; ERR=ERREUR; BCL=BOUCLE; APL=APPEL; PRG=PROGRAMME  *
-      * VID=VIDE; APP=APPUI; ENT=ENTREE.                               *
+      * VID=VIDE; APP=APPUI; ENT=ENTREE; PCP=PRINCIPALE.               *
       ******************************************************************
        
        IDENTIFICATION DIVISION.
@@ -179,12 +179,21 @@
 
        PROCEDURE DIVISION.
 
+           PERFORM 0090-BCL-PCP-DEB
+              THRU 0090-BCL-PCP-FIN.
+
+           EXIT PROGRAM.
+
+      ******************************************************************
+      *                         PARAGRAPHES                            * 
+      ******************************************************************
+
       * Affichage de l'écran de création d'utilisateur.
       * Tant que le mot de passe n'est pas confirmé ou que 
       * l'utilisateur ne choisit pas l'une des 2 options proposées, on
       * reste dans la boucle et l'utilisateur peut à nouveau saisir 
       * ses données.
-
+       0090-BCL-PCP-DEB.
            SET WS-FIN-BCL-NON TO TRUE.
 
            PERFORM UNTIL WS-FIN-BCL-OUI
@@ -193,11 +202,7 @@
 
            END-PERFORM.
 
-           EXIT PROGRAM.
-
-      ******************************************************************
-      *                         PARAGRAPHES                            * 
-      ******************************************************************
+       0090-BCL-PCP-FIN.
 
        0100-AFF-ECR-UTI-DEB.
 


### PR DESCRIPTION
Création de l'écran en SCREEN SECTION pour entrer les informations afin de créer un utilisateur. Le programme appelle la sous-programme "creuti" du CP-012 afin d'insérer les informations entrées en SCREEN SECTION dans la base de données (BDD) SQL.

N'ayant pas de code retour afin de contrôler l'insertion ou non des informations entrées dans la BDD dans mon programme appelé, j'ai simulé un code retour dans mon programme appelant afin de pouvoir afficher les messages correspondant à la situation "simulée" dans ma SCREEN SECTION.

La review binôme a été faite avec Sibory.