### PR TITLE
CP-025 ecran ajout client

### DIFF
--- a/srcs/client/ecrajcli.cbl
+++ b/srcs/client/ecrajcli.cbl
@@ -239,8 +239,10 @@
         
        0400-APL-VER-EMA-DEB.
 
-           CALL "verema" USING WS-EMA-CLI 
-                               WS-VLR-RTR
+           CALL "verema"
+               USING
+               WS-EMA-CLI 
+               WS-VLR-RTR
            END-CALL.
 
       * Affichage à l'écran du message de retour après vérification de  
@@ -358,14 +360,15 @@
       * clients dans la BDD.  
        0500-APL-AJ-CLI-BDD-DEB.
 
-           CALL "ajucli" USING WS-NOM-CLI
-                               WS-EMA-CLI
-                               WS-IND-CLI
-                               WS-TEL-CLI
-                               WS-COP-CLI
-                               WS-VIL-CLI
-                               WS-ADR-CLI
-
+           CALL "ajucli"
+                USING
+                WS-NOM-CLI
+                WS-EMA-CLI
+                WS-IND-CLI
+                WS-TEL-CLI
+                WS-COP-CLI
+                WS-VIL-CLI
+                WS-ADR-CLI
            END-CALL.
            EXIT.
 


### PR DESCRIPTION
Ce sous-programme est un écran de saisie des informations d'un client à ajouter. Celui-ci appelle un sous-programme de de vérification de l'email saisi par l'utilisateur et un autre d'ajout du client dans la BDD. L'utilisateur a le choix d'ajouter un client ou non à partir de l'écran. Le programme de SCREEN SECTION boucle tant que l'email saisi n'est pas valide et n'ajoute un client dans la BDD que lorsque l'email est vérifié.

**Problème rencontré** : je n'ai pas réussi à trouver comment nettoyer les champs de saisie de mon écran à chaque itération de ma boucle même après avoir demandé de l'aide.

La review binôme a été faite avec Lucas.