### PR TITLE
CP-067 Mise a jour info piece

### DIFF
--- a/srcs/piece/mjinfpie.cbl
+++ b/srcs/piece/mjinfpie.cbl
@@ -2,29 +2,129 @@
       *                             ENTÊTE                             *
       *                                                                *
       *                                                                *
-      *                                                                *
+      *----------------------------------------------------------------*
       *                           TRIGRAMMES                           *
-      * MJ=MISE A JOUR; INF=INFO; PIE=PIECE;                           *
       *                                                                *
-      *                                                                *
+      * MJ=MISE A JOUR; INF=INFO; PIE=PIECE; IDF=IDENTIFIANT;          *
+      * SUL= SEUIL; FOU=FOURNISSEUR; VAR=VARIABLE; INI= INITIALISATION;*
+      * MSG=MESSAGE; EDT=EDITION;                                      *
       ******************************************************************
        
        IDENTIFICATION DIVISION.
        PROGRAM-ID. mjinfpie.
-       AUTHOR. .
-       DATE-WRITTEN. .
+       AUTHOR. ThomasD.
+       DATE-WRITTEN. 07-07-2025 (fr).
 
        DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       
+      * Déclaration de la variable stockant le message à inclure dans 
+      * les logs à chaque opération.  
+       01 WS-MSG-LOG           PIC X(100).
+
+      * Déclaration de la variable définissant le type de log. 
+       01 WS-TYP-LOG           PIC X(12). 
+
+       01 WS-IDF-PIE-EDT       PIC Z(10).
+
+       EXEC SQL BEGIN DECLARE SECTION END-EXEC.
+
+       01 PG-IDF-PIE               PIC 9(10).
+       01 PG-NOM-PIE               PIC X(50).
+       01 PG-SUL-PIE               PIC 9(10).
+       01 PG-IDF-FOU-PIE           PIC 9(10).
+
+       EXEC SQL END DECLARE SECTION END-EXEC.
+       EXEC SQL INCLUDE SQLCA END-EXEC.
+       
        LINKAGE SECTION.
       * Arguments d'entrée.
-       01 IDENTIFIANT          PIC 9(10).
-       01 NOM                  PIC X(50).
-       01 SEUIL                PIC 9(10).
-       01 ID-FOUR              PIC 9(10).
+       01 LK-IDF-PIE               PIC 9(10).
+       01 LK-NOM-PIE               PIC X(50).
+       01 LK-SUL-PIE               PIC 9(10).
+       01 LK-IDF-FOU-PIE           PIC 9(10).
 
-       PROCEDURE DIVISION USING IDENTIFIANT,
-                                NOM,
-                                SEUIL,
-                                ID-FOUR.
+
+
+
+       PROCEDURE DIVISION USING LK-IDF-PIE,
+                                LK-NOM-PIE,
+                                LK-SUL-PIE,
+                                LK-IDF-FOU-PIE.
+           
+
+           PERFORM 0100-INI-VAR-DEB
+              THRU 0100-INI-VAR-FIN.
+
+           PERFORM 0200-SQL-DEB
+              THRU 0200-SQL-FIN.   
+           
+           PERFORM 0300-GEN-LOG-DEB
+              THRU 0300-GEN-LOG-FIN.
 
            EXIT PROGRAM.
+       
+
+      ******************************************************************
+      *                         PARAGRAPHES                            * 
+      ****************************************************************** 
+
+       0100-INI-VAR-DEB.
+           
+           MOVE LK-IDF-PIE
+           TO   PG-IDF-PIE.
+           
+           MOVE LK-NOM-PIE
+           TO   PG-NOM-PIE.
+
+           MOVE LK-SUL-PIE
+           TO   PG-SUL-PIE.
+           
+           MOVE LK-IDF-FOU-PIE
+           TO   PG-IDF-FOU-PIE.
+           
+      * Alimentation de la variable correspondant au type de log.     
+           MOVE 'piece'
+           TO   WS-TYP-LOG.
+           
+           EXIT.
+       0100-INI-VAR-FIN
+
+      *----------------------------------------------------------------- 
+       0200-SQL-DEB.
+           
+           EXEC SQL 
+               UPDATE piece 
+               SET nom_pie = :PG-NOM-PIE,
+                   seuil_pie = :PG-SUL-PIE,
+                   id_fou = :PG-IDF-FOU-PIE
+               WHERE id_pie = :PG-IDF-PIE
+           END-EXEC.
+           
+             IF SQLCODE = 0
+      * L'utilisateur est modifié avec succès.
+               EXEC SQL COMMIT END-EXEC
+           ELSE
+      * L'utilisateur n'est pas dans la table ou la table n'existe pas.
+               EXEC SQL ROLLBACK END-EXEC
+           END-IF.
+
+           EXIT.
+       0200-SQL-FIN.
+
+      *----------------------------------------------------------------- 
+       
+       0300-GEN-LOG-DEB.
+           
+           STRING '[' DELIMITED BY SIZE 
+                  FUNCTION TRIM (WS-IDF-PIE-EDT) DELIMITED BY SIZE 
+                  '] ' DELIMITED BY SIZE 
+                  'Modifications des informations sur la piece'
+           INTO WS-MSG-LOG
+           END-STRING.
+
+           EXIT.
+       0300-GEN-LOG-FIN.
+
+      *----------------------------------------------------------------- 
+       

--- a/srcs/piece/mjinfpie.cbl
+++ b/srcs/piece/mjinfpie.cbl
@@ -169,10 +169,11 @@
       * de log défini dans ce programme et l'id utilisateur en 
       * arguments. 
 
-           CALL "crelog" USING WS-MSG-LOG
-                               WS-TYP-LOG
-                               WS-IDF-UTI
-           
+           CALL "crelog"
+               USING 
+               WS-MSG-LOG
+               WS-TYP-LOG
+               WS-IDF-UTI
            END-CALL.
 
            EXIT.

--- a/srcs/piece/mjinfpie.cbl
+++ b/srcs/piece/mjinfpie.cbl
@@ -1,0 +1,30 @@
+      ******************************************************************
+      *                             ENTÊTE                             *
+      *                                                                *
+      *                                                                *
+      *                                                                *
+      *                           TRIGRAMMES                           *
+      * MJ=MISE A JOUR; INF=INFO; PIE=PIECE;                           *
+      *                                                                *
+      *                                                                *
+      ******************************************************************
+       
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. mjinfpie.
+       AUTHOR. .
+       DATE-WRITTEN. .
+
+       DATA DIVISION.
+       LINKAGE SECTION.
+      * Arguments d'entrée.
+       01 IDENTIFIANT          PIC 9(10).
+       01 NOM                  PIC X(50).
+       01 SEUIL                PIC 9(10).
+       01 ID-FOUR              PIC 9(10).
+
+       PROCEDURE DIVISION USING IDENTIFIANT,
+                                NOM,
+                                SEUIL,
+                                ID-FOUR.
+
+           EXIT PROGRAM.


### PR DESCRIPTION
Sous-programme servant à mettre à jour les infos des pièces en stock (sauf la quantité) et génère le message de log à envoyer au sous-programme "crelog" avec les variables correspondant au type de log et l'id utilisateur.  Le nom de la pièce, seuil pièce, id fournisseur sont donc modifiés à l'aide de ce programme. 

 