### PR TITLE
CP-060 ecran mise a jour livraison

### DIFF
--- a/srcs/livraison/ecrmjliv.cbl
+++ b/srcs/livraison/ecrmjliv.cbl
@@ -337,14 +337,14 @@
 
       * Mise à jour du stock des pièces comprises dans la livraison 
       * correspondante.
-
-               CALL "majpie"
-                   USING
-                   WS-IDF-PIE
-                   WS-QTE-PIE
-                   WS-TYP-CHG
-               END-CALL
-               
+               IF WS-RET-DON-LUE
+                   CALL "majpie"
+                       USING
+                       WS-IDF-PIE
+                       WS-QTE-PIE
+                       WS-TYP-CHG
+                   END-CALL
+               END-IF 
 
            END-PERFORM.
            


### PR DESCRIPTION
Sous-programme créant un écran pour la mise à jour de livraison. L'ID de livraison à modifier (livraison à passer de "en cours" à "terminé") est saisi à l'écran. Il appelle d'abord liridliv pour stocker les informations de livraison correspondant à l'ID saisi. Puis le programme appelle majliv après avoir vérifié si la livraison est en cours ou bien terminée (dans ce cas aucune mise à jour n'est requise), pour ensuite appeler fetlivpi et majpie si la livraison est entrante.