### PR TITLE
CP-059 lire livraisons par page

### DIFF
--- a/srcs/livraison/lirpgliv.cbl
+++ b/srcs/livraison/lirpgliv.cbl
@@ -1,6 +1,8 @@
       ******************************************************************
       *                             ENTÊTE                             *
-      *                                                                *
+      * Programme qui récupère les livraisons par page et les retourne *
+      * au programme appelant. Le programme prend en paramètre la      *
+      * quantité de données à retourner, ainsi que la page à retourner.*
       *                                                                *
       *----------------------------------------------------------------*
       *                           TRIGRAMMES                           *
@@ -9,7 +11,7 @@
       * FIL=FILTRE; VID=VIDE; TAB=TABLEAU; LIV=LIVRAISON; DAT=DATE;    *
       * STA=STATUT; CRS=COURS; TRM=TERMINE; TYP=TYPE; ENT=ENTRANT;     *
       * SOR=SORTANT; QTE=QUANTITE; OFS=OFFSET; LIN=LIGNE;              *
-      * EVA=EVALUATION; CSR= CURSEUR; AFC= AFFECTATION
+      * EVA=EVALUATION; CSR= CURSEUR; AFC= AFFECTATION.                *
       ******************************************************************
        
        IDENTIFICATION DIVISION.


### PR DESCRIPTION
Sous-programme permettant la lecture par page des livraisons. Il a nécessité l'utilisation de CURSOR et de FETCH ainsi que de fonctions telles que COALESCE et COUNT en SQL pour récupérer les informations demandées. Le programme retourne un tableau contenant les variables alimentées qui vont être renvoyées au programme appelant (l'écran correspondant).